### PR TITLE
fix pending events on load

### DIFF
--- a/src/test/groovy/io/pillopl/eventsourcing/persistence/CreditCardRepositoryTest.groovy
+++ b/src/test/groovy/io/pillopl/eventsourcing/persistence/CreditCardRepositoryTest.groovy
@@ -24,6 +24,44 @@ class CreditCardRepositoryTest extends Specification {
             CreditCard loaded = creditCardRepository.load(uuid)
         then:
             loaded.availableLimit() == 90
-            loaded.getPendingEvents().size() == 0
+    }
+
+    def 'should not have pending events after load'() {
+        given:
+            UUID uuid = UUID.randomUUID()
+        when:
+            CreditCard loaded = creditCardRepository.load(uuid)
+        then:
+            loaded.pendingEvents.size() == 0
+    }
+
+    def 'should not have pending events after save'() {
+        given:
+            UUID uuid = UUID.randomUUID()
+        and:
+            CreditCard card = new CreditCard(uuid)
+        and:
+            card.assignLimit(100)
+        when:
+            creditCardRepository.save(card)
+        then:
+            card.pendingEvents.size() == 0
+    }
+
+    def 'should not have pending events after save and load'() {
+        given:
+            UUID uuid = UUID.randomUUID()
+        and:
+            CreditCard card = new CreditCard(uuid)
+        and:
+            card.assignLimit(100)
+        when:
+            creditCardRepository.save(card)
+        and:
+            CreditCard loaded = creditCardRepository.load(uuid)
+        then:
+            loaded.pendingEvents.size() == 0
+        and:
+            card.pendingEvents.size() == 0
     }
 }

--- a/src/test/groovy/io/pillopl/eventsourcing/persistence/CreditCardRepositoryTest.groovy
+++ b/src/test/groovy/io/pillopl/eventsourcing/persistence/CreditCardRepositoryTest.groovy
@@ -24,5 +24,6 @@ class CreditCardRepositoryTest extends Specification {
             CreditCard loaded = creditCardRepository.load(uuid)
         then:
             loaded.availableLimit() == 90
+            loaded.getPendingEvents().size() == 0
     }
 }


### PR DESCRIPTION
Hi Jakub!

What do you think the pending list of events should be empty after loading the card from the repository?
If not, after loading we have all previous events on the pending list, so then, each previous event will be republished again.